### PR TITLE
Fix for update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - sudo apt-get update -qq
   - sudo apt-get install -y software-properties-common python-software-properties lxc-dev
   - go get -u -v gopkg.in/alecthomas/gometalinter.v2
-  - go get -v github.com/honeytrap/honeytrap
+  - go get -u -v github.com/honeytrap/honeytrap
   - gometalinter.v2 --install
 
 script:


### PR DESCRIPTION
Check for travis update honeytrap, after submodule gopher-lua has been disabled.